### PR TITLE
README as cookbook_file

### DIFF
--- a/cookbooks/vm/files/default/README.md
+++ b/cookbooks/vm/files/default/README.md
@@ -1,0 +1,47 @@
+# Developer VM README
+
+## Updating the VM
+
+For applying the current configuration to the VM:
+
+  * simply run `update-vm`
+
+For updating to the latest configuration and applying that:
+
+  * simply run `update-vm --pull`
+
+For verifying the current configuration without applying anything:
+
+  * simply run `update-vm --verify-only`
+
+## Keyboard Layout
+
+In order to switch the keyboard layout please run:
+```
+sudo dpkg-reconfigure keyboard-configuration
+```
+
+## Setup a Java / Maven Example
+
+You can set up a Maven based example REST service as described here:
+https://jersey.java.net/documentation/latest/getting-started.html
+
+Prepare:
+```
+mkdir ~/workspace
+cd ~/workspace
+```
+
+Create the web project:
+```
+mvn archetype:generate -DarchetypeArtifactId=jersey-quickstart-webapp \
+  -DarchetypeGroupId=org.glassfish.jersey.archetypes -DinteractiveMode=false \
+  -DgroupId=com.example -DartifactId=simple-service-webapp -Dpackage=com.example \
+  -DarchetypeVersion=2.21
+```
+
+Build, test, package:
+```
+cd simple-service-webapp
+mvn clean install
+```

--- a/cookbooks/vm/recipes/base.rb
+++ b/cookbooks/vm/recipes/base.rb
@@ -20,39 +20,11 @@ directory '/home/vagrant/Desktop' do
   owner 'vagrant'
   group 'vagrant'
   mode '0755'
-  action :create
 end
 
-file '/home/vagrant/Desktop/README' do
+cookbook_file '/home/vagrant/Desktop/README.md' do
+  source 'README.md'
   owner 'vagrant'
   group 'vagrant'
   mode '0644'
-  action :create
-  content <<-EOF
-# Developer VM README
-
-
-## Updating the VM
-
-For applying the current configuration to the VM:
-
-  * simply run `update-vm`
-
-For updating to the latest configuration and applying that:
-
-  * simply run `update-vm --pull`
-
-For verifying the current configuration without applying anything:
-
-  * simply run `update-vm --verify-only`
-
-
-## Keyboard Layout
-
-In order to switch the keyboard layout please run:
-```
-sudo dpkg-reconfigure keyboard-configuration
-```
-
-EOF
 end

--- a/cookbooks/vm/spec/integration/recipes/base_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/base_spec.rb
@@ -15,6 +15,6 @@ describe 'vm::base' do
   end
 
   it 'places a README on the Desktop' do
-    expect(file('/home/vagrant/Desktop/README')).to exist
+    expect(file('/home/vagrant/Desktop/README.md')).to exist
   end
 end


### PR DESCRIPTION
* use `cookbook_file` for the README since it got bigger
* add instructions how to generate a Maven example project